### PR TITLE
Use http in links to remotes

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -8,7 +8,7 @@
     <link href="lib/ionic/css/ionic.css" rel="stylesheet">
     <link href="css/style.css" rel="stylesheet">
 
-    <link rel="stylesheet" href="//js.arcgis.com/4.0beta3/esri/css/main.css">
+    <link rel="stylesheet" href="http://js.arcgis.com/4.0beta3/esri/css/main.css">
 
     <!-- IF using Sass (run gulp sass first), then uncomment below and remove the CSS includes above
     <link href="css/ionic.app.css" rel="stylesheet">
@@ -21,9 +21,9 @@
     <script src="cordova.js"></script>
 
     <!-- load Esri JSAPI -->
-    <script src="//js.arcgis.com/4.0beta3/"></script>
+    <script src="http://js.arcgis.com/4.0beta3/"></script>
     <!-- load angular-esri-map -->
-    <script src="//npmcdn.com/angular-esri-map@2.0.0-beta.2"></script>
+    <script src="http://npmcdn.com/angular-esri-map@2.0.0-beta.2"></script>
 
     <!-- your app's js -->
     <script src="js/app.js"></script>


### PR DESCRIPTION
In `index.html`, add `http` alias to script links. Otherwise, Android interprets the links as `file:` references and the app breaks.
